### PR TITLE
Use ListPair.allEq rather than ListPair.all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 *.log
 *.toc
 .cm
-*.grm
 *.grm.desc
 *.grm.sig
 *.grm.sml

--- a/abbot_impl.sml
+++ b/abbot_impl.sml
@@ -234,7 +234,7 @@ local
                 (VarPat str1,
                  VarPat str2,
                  SeqExp
-                   [ExpVar "ListPair.all",
+                   [ExpVar "ListPair.allEq",
                     LamExp [(TuplePat [pat1, pat2], exp)],
                     TupleExp [ExpVar str1, ExpVar str2]])
               end,

--- a/abbot_impl.sml
+++ b/abbot_impl.sml
@@ -1245,9 +1245,9 @@ fun create_mutual_utils (ana : ana) (abts, sorts) =
                     [] => exp
                   | _ =>
                     SeqExp
-                      (ExpVar (Big ext ^ ".map")
+                      (ExpVar (Big (ext_to_string ext) ^ ".map")
                        :: List.map (fn patexp => LamExp [patexp]) patexps
-                       @ [exp]),
+                       @ [exp])),
                abtf =
                fn abt =>
                   if #dependson ana (Abt abt) (Sort sort)


### PR DESCRIPTION
We want to make sure the lengths are equal in addition to the values
being equal.

Note that this PR includes a couple other "spring cleaning" things:

- It looks like a [recent commit](ccb65bd) was pushed before testing,
  which introduced syntax errors.

- Another recent commit ignores `*.grm` files. We probably want to keep
  these around. It's the `*.grm.sml` and `*.grm.sig` files (the
  autogenerated ones) that we want to ignore.