### PR TITLE
Fix equality on external aequiv for symbols

### DIFF
--- a/abbot_impl.sml
+++ b/abbot_impl.sml
@@ -183,13 +183,20 @@ local
               let
                 val str1 = index (sym_to_string sym)
                 val str2 = index (sym_to_string sym)
+                val aequiv =
+                  if internal_abt then
+                    SeqExp
+                     [ExpVar "Abt.aequiv",
+                      LamExp [(Wild, ExpVar "true")],
+                      TupleExp [ExpVar str1, ExpVar str2]]
+                  else
+                    SeqExp
+                     [ExpVar (Big (sym_to_string sym) ^ ".equal"),
+                      TupleExp [ExpVar str1, ExpVar str2]]
               in
                 (VarPat str1,
                  VarPat str2,
-                 SeqExp
-                   [ExpVar "Abt.aequiv",
-                    LamExp [(Wild, ExpVar "true")],
-                    TupleExp [ExpVar str1, ExpVar str2]])
+                 aequiv)
               end,
            sort_usef =
            fn sort =>


### PR DESCRIPTION
When we generate equivalence functions for ABTs that utilize symbols, the internal comparison works as expected since symbols are internally `unit Abt.t` which can be compared using `Abt.aequiv`. 

However, generated external `aequiv` fails to compile because it still uses `Abt.aequiv` to compare `Temp.t` when it should use `Temp.equal`. This patch remedies the bug, which seems to have been introduced in 02b8f27ee5e3143b0bfcab5a8ac55e8e27f235f6.

In the following example, we have:
```sml
  datatype typ
    = Nat
    | Arrow of typ * typ
    | Prod of (Label.t * typ) list
    | Sum of (Label.t * typ) list
```

Before patch:
```sml
    | ((Prod list'5), (Prod list'6)) =>
      (ListPair.allEq (fn ((label'1, typ'3), (label'2, typ'4)) =>
        ((Abt.aequiv (fn _ =>
          true
        ) (label'1, label'2)) andalso (typ_aequiv (typ'3, typ'4)))
      ) (list'5, list'6))
```

After:
```sml
    | ((Prod list'5), (Prod list'6)) =>
      (ListPair.allEq (fn ((label'1, typ'3), (label'2, typ'4)) =>
        ((Label.equal (label'1, label'2)) andalso (typ_aequiv (typ'3, typ'4)))
      ) (list'5, list'6))
```